### PR TITLE
PR: Implement an AST builder

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -1,7 +1,7 @@
 use std::{fmt::Error, num::ParseFloatError};
 
 #[derive(Debug, PartialEq, Clone)]
-enum Token<'a> {
+pub enum Token<'a> {
     EOF,
     // commands
     Def,
@@ -12,13 +12,13 @@ enum Token<'a> {
 }
 
 // An iterator state holder for tokens
-struct TokenIter<'a> {
+pub struct TokenIter<'a> {
     tok: Token<'a>,
     remainder: &'a str,
 }
 
 impl<'a> TokenIter<'a> {
-    fn new(input: &'a str) -> TokenIter {
+    pub fn new(input: &'a str) -> TokenIter {
         TokenIter {
             // the initial token has to be set to something
             // maybe EOF can be replaced with None instead
@@ -41,7 +41,7 @@ impl<'a> Iterator for TokenIter<'a> {
 // parse tokens through a view of the whole input
 // only a view is needed because parsing into the language tokens
 // does not need to mutate the input string
-fn parse_input<'a>(input: &'a str) -> (Token<'a>, &'a str) {
+pub fn parse_input<'a>(input: &'a str) -> (Token<'a>, &'a str) {
     // the view of the whole input, trimming the whitespace start
     let substr = input.trim_start();
     // the counter for where to split later

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -176,4 +176,17 @@ mod tests {
         // from here on the token produced should be Token::EOF
         assert_eq!(Some(Token::EOF), tok_iter.next());
     }
+
+    #[test]
+    fn test_parens() {
+        let input = "def function(x, y)".to_string();
+        let mut tokenstream = TokenIter::new(&input);
+        assert_eq!(Some(Token::Def), tokenstream.next());
+        assert_eq!(Some(Token::Identifier("function")), tokenstream.next());
+        assert_eq!(Some(Token::Identifier("(")), tokenstream.next());
+        assert_eq!(Some(Token::Identifier("x")), tokenstream.next());
+        assert_eq!(Some(Token::Identifier(",")), tokenstream.next());
+        assert_eq!(Some(Token::Identifier("y")), tokenstream.next());
+        assert_eq!(Some(Token::Identifier(")")), tokenstream.next());
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod lexer;
+pub mod parser;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -46,13 +46,13 @@ struct FunctionExpr<'a> {
 }
 
 // A primitive AST node is without any sub-nodes
-fn make_primitive<'a>(tok: &Token<'a>) -> ExprAST<'a> {
+fn make_primitive<'a>(tok: Option<&Token<'a>>) -> Option<ExprAST<'a>> {
     match tok {
-        Token::Identifier(str) => ExprAST::Variable(VariableExpr { name: str }),
-        Token::Number(value) => ExprAST::Number(NumberExpr {
+        Some(Token::Identifier(str)) => Some(ExprAST::Variable(VariableExpr { name: str })),
+        Some(Token::Number(value)) => Some(ExprAST::Number(NumberExpr {
             value: value.clone(),
-        }),
-        _ => panic!("Expected primitive!"),
+        })),
+        _ => None,
     }
 }
 
@@ -60,7 +60,7 @@ fn make_primitive<'a>(tok: &Token<'a>) -> ExprAST<'a> {
 fn get_opcode<'a>(tok: &Token<'a>) -> Option<(char, i32)> {
     match tok {
         Token::Identifier("+") => Some(('+', 50)),
-        Token::Identifier("-") => Some(('-', 60)),
+        Token::Identifier("-") => Some(('-', 40)),
         Token::Identifier("*") => Some(('*', 80)),
         Token::Identifier("<") => Some(('<', 100)),
         _ => None,
@@ -74,25 +74,26 @@ fn get_opcode<'a>(tok: &Token<'a>) -> Option<(char, i32)> {
 // the prec is the precendence value
 // this currently only makes an expression with all rhs expanded
 // a parser needs to construct the total AST
-fn make_expr<'a>(tok_iter: &'a mut Peekable<TokenIter>, prec: i32) -> ExprAST<'a> {
-    let lhs = make_primitive(&tok_iter.next().unwrap());
+fn make_expr<'a>(tok_iter: &mut Peekable<TokenIter<'a>>, prec: i32) -> ExprAST<'a> {
+    let mut lhs = make_primitive(tok_iter.next().as_ref());
 
-    match get_opcode(tok_iter.peek().expect("Reached end!")) {
-        Some(opcode) => {
-            tok_iter.next();
-            let rhs: ExprAST<'a>;
-            if opcode.1 <= prec {
-                rhs = make_expr(tok_iter, prec);
-            } else {
-                rhs = make_primitive(&tok_iter.next().unwrap());
-            }
-            ExprAST::BinaryOp(Box::new(BinaryOpExpr {
-                op: opcode.0,
-                args: [lhs, rhs],
-            }))
-        }
-        None => lhs,
+    loop {
+        let (op, new_prec) = match get_opcode(tok_iter.peek().unwrap()) {
+            Some((opcode, new_prec)) => (opcode, new_prec),
+            // a negative value to ensure the break when reaching EOF
+            _ => ('#', -1000),
+        };
+        if new_prec < prec {
+            break;
+        };
+        tok_iter.next();
+        let rhs = make_expr(tok_iter, new_prec);
+        lhs = Some(ExprAST::BinaryOp(Box::new(BinaryOpExpr {
+            op,
+            args: [lhs.unwrap(), rhs],
+        })));
     }
+    lhs.unwrap()
 }
 
 #[cfg(test)]
@@ -105,11 +106,11 @@ mod tests {
         let mut tok_iter = TokenIter::new(&input).peekable();
         let mut tmp_iter = TokenIter::new(&input).peekable();
 
-        let lhs = make_primitive(tok_iter.peek().unwrap());
+        let lhs = make_primitive(tok_iter.peek()).unwrap();
         assert_eq!(ExprAST::Variable(VariableExpr { name: "x" }), lhs);
         tok_iter.next();
         tok_iter.next();
-        let rhs = make_primitive(tok_iter.peek().unwrap());
+        let rhs = make_primitive(tok_iter.peek()).unwrap();
         assert_eq!(ExprAST::Number(NumberExpr { value: 2.0 }), rhs);
 
         let result = ExprAST::BinaryOp(Box::new(BinaryOpExpr {
@@ -126,21 +127,25 @@ mod tests {
         let mut tok_iter = TokenIter::new(&input).peekable();
         let mut tmp_iter = TokenIter::new(&input).peekable();
 
-        let prim_x = make_primitive(tmp_iter.peek().unwrap());
+        let prim_x = make_primitive(tmp_iter.peek()).unwrap();
         assert_eq!(ExprAST::Variable(VariableExpr { name: "x" }), prim_x);
         tmp_iter.next();
         tmp_iter.next();
-        let prim_y = make_primitive(tmp_iter.peek().unwrap());
+        let prim_y = make_primitive(tmp_iter.peek()).unwrap();
         assert_eq!(ExprAST::Variable(VariableExpr { name: "y" }), prim_y);
 
         tmp_iter.next();
         tmp_iter.next();
-        let prim_r = make_primitive(tmp_iter.peek().unwrap());
+        let prim_r = make_primitive(tmp_iter.peek()).unwrap();
         assert_eq!(ExprAST::Number(NumberExpr { value: 2.0 }), prim_r);
 
-        let result = ExprAST::BinaryOp(Box::new(BinaryOpExpr {
+        let lhs = ExprAST::BinaryOp(Box::new(BinaryOpExpr {
             op: '+',
             args: [prim_x, prim_y],
+        }));
+        let result = ExprAST::BinaryOp(Box::new(BinaryOpExpr {
+            op: '-',
+            args: [lhs, prim_r],
         }));
         let binop = make_expr(&mut tok_iter, 0);
         assert_eq!(result, binop);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -57,13 +57,14 @@ fn make_primitive<'a>(tok: Option<&Token<'a>>) -> Option<ExprAST<'a>> {
 }
 
 // should be impl for the Token?
-fn get_opcode<'a>(tok: &Token<'a>) -> Option<(char, i32)> {
+fn get_opcode<'a>(tok: Option<&Token<'a>>) -> (char, i32) {
     match tok {
-        Token::Identifier("+") => Some(('+', 50)),
-        Token::Identifier("-") => Some(('-', 40)),
-        Token::Identifier("*") => Some(('*', 80)),
-        Token::Identifier("<") => Some(('<', 100)),
-        _ => None,
+        Some(Token::Identifier("+")) => ('+', 50),
+        Some(Token::Identifier("-")) => ('-', 40),
+        Some(Token::Identifier("*")) => ('*', 80),
+        Some(Token::Identifier("<")) => ('<', 100),
+        // default
+        _ => ('#', -1000),
     }
 }
 
@@ -71,18 +72,16 @@ fn get_opcode<'a>(tok: &Token<'a>) -> Option<(char, i32)> {
 // almost all commands in a program are actually binary operations
 // the basic commands of a asm language are usually binop:
 // move, add, load
-// the prec is the precendence value
+// the prec is the precendence binding value of the operation
 // this currently only makes an expression with all rhs expanded
 // a parser needs to construct the total AST
 fn make_expr<'a>(tok_iter: &mut Peekable<TokenIter<'a>>, prec: i32) -> ExprAST<'a> {
     let mut lhs = make_primitive(tok_iter.next().as_ref());
 
     loop {
-        let (op, new_prec) = match get_opcode(tok_iter.peek().unwrap()) {
-            Some((opcode, new_prec)) => (opcode, new_prec),
-            // a negative value to ensure the break when reaching EOF
-            _ => ('#', -1000),
-        };
+        let (op, new_prec) = get_opcode(tok_iter.peek());
+        // if the new precedence binding is lower
+        // it's time to break out of the loop
         if new_prec < prec {
             break;
         };

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,58 +1,102 @@
-use crate::lexer::{parse_input, TokenIter};
+use crate::lexer::{parse_input, Token, TokenIter};
+use std::iter::Peekable;
 // all of the possible Abstract Syntax Tree node expressions
+#[derive(Debug, PartialEq)]
 enum ExprAST<'a> {
     Number(NumberExpr),
     Variable(VariableExpr<'a>),
-    BinaryOp(&'a BinaryOpExpr<'a>),
+    BinaryOp(Box<BinaryOpExpr<'a>>),
     CallOp(CallOpExpr<'a>),
     FnType(FnTypeExpr<'a>),
-    Function(&'a FunctionExpr<'a>),
+    Function(Box<FunctionExpr<'a>>),
 }
 
+#[derive(Debug, PartialEq)]
 struct NumberExpr {
     value: f64,
 }
 
+#[derive(Debug, PartialEq)]
 struct VariableExpr<'a> {
     name: &'a str,
 }
 
+#[derive(Debug, PartialEq)]
 struct BinaryOpExpr<'a> {
     op: char,
     args: [ExprAST<'a>; 2],
 }
 
+#[derive(Debug, PartialEq)]
 struct CallOpExpr<'a> {
     callee: &'a str,
     args: Vec<ExprAST<'a>>,
 }
 
+#[derive(Debug, PartialEq)]
 struct FnTypeExpr<'a> {
     name: &'a str,
     args: Vec<&'a str>,
 }
 
+#[derive(Debug, PartialEq)]
 struct FunctionExpr<'a> {
     ty: FnTypeExpr<'a>,
     body: ExprAST<'a>,
 }
 
+// should be impl for the Token?
+fn make_variable<'a>(tok: &Token<'a>) -> ExprAST<'a> {
+    match tok {
+        Token::Identifier(str) => ExprAST::Variable(VariableExpr { name: str }),
+        _ => panic!("Variable not parsed!"),
+    }
+}
+
+// should be impl for the Token?
+fn get_opcode<'a>(tok: &Token<'a>) -> Option<char> {
+    match tok {
+        Token::Identifier(opcode) => opcode.chars().next(),
+        _ => panic!("Error in retrieving opcode!"),
+    }
+}
+
+// should be impl for the TokenIter?
+fn make_binop<'a>(tok_iter: &'a mut Peekable<TokenIter>) -> ExprAST<'a> {
+    let lhs = make_variable(&tok_iter.next().unwrap());
+    // peek to the next to see if it is a binop:
+    let op = get_opcode(tok_iter.peek().unwrap());
+    tok_iter.next();
+    let rhs = make_variable(tok_iter.peek().unwrap());
+
+    ExprAST::BinaryOp(Box::new(BinaryOpExpr {
+        op: op.unwrap(),
+        args: [lhs, rhs],
+    }))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::iter::Peekable;
 
     #[test]
     fn test_binop() {
         let input = "x + y";
         let mut tok_iter = TokenIter::new(&input).peekable();
+        let mut tmp_iter = TokenIter::new(&input).peekable();
 
-        let lhs = ExprAST::Variable(VariableExpr { name: "x" });
-        let rhs = ExprAST::Variable(VariableExpr { name: "y" });
+        let lhs = make_variable(tok_iter.peek().unwrap());
+        assert_eq!(ExprAST::Variable(VariableExpr { name: "x" }), lhs);
+        tok_iter.next();
+        tok_iter.next();
+        let rhs = make_variable(tok_iter.peek().unwrap());
+        assert_eq!(ExprAST::Variable(VariableExpr { name: "y" }), rhs);
 
-        let result = BinaryOpExpr {
+        let result = ExprAST::BinaryOp(Box::new(BinaryOpExpr {
             op: '+',
             args: [lhs, rhs],
-        };
+        }));
+        let binop = make_binop(&mut tmp_iter);
+        assert_eq!(result, binop)
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -124,33 +124,33 @@ fn make_signature<'a>(tokenstream: &mut Peekable<TokenIter<'a>>) -> FnTypeExpr<'
     }
 }
 
-fn make_function<'a>(tokenstream: &mut Peekable<TokenIter<'a>>) -> ExprAST<'a> {
+fn make_function<'a>(tokenstream: &mut Peekable<TokenIter<'a>>) -> FunctionExpr<'a> {
     let ty = make_signature(tokenstream);
     let body = make_expr(tokenstream, 0);
-    ExprAST::Function(Box::new(FunctionExpr { ty, body }))
+    FunctionExpr { ty, body }
 }
 
 // parsers a top level expression into an anonymous function
-fn make_topexpr<'a>(tokenstream: &mut Peekable<TokenIter<'a>>) -> ExprAST<'a> {
+fn make_topexpr<'a>(tokenstream: &mut Peekable<TokenIter<'a>>) -> FunctionExpr<'a> {
     let topty = FnTypeExpr {
         name: "",
         args: Vec::new(),
     };
     let body = make_expr(tokenstream, 0);
-    ExprAST::Function(Box::new(FunctionExpr { ty: topty, body }))
+    FunctionExpr { ty: topty, body }
 }
 
 fn make_ast<'a>(tokenstream: &mut Peekable<TokenIter<'a>>) -> ExprAST<'a> {
     match tokenstream.peek() {
         Some(Token::Def) => {
             tokenstream.next();
-            make_function(tokenstream)
+            ExprAST::Function(Box::new(make_function(tokenstream)))
         }
         Some(Token::Extern) => {
             tokenstream.next();
-            make_function(tokenstream)
+            ExprAST::Function(Box::new(make_function(tokenstream)))
         }
-        _ => make_topexpr(tokenstream),
+        _ => ExprAST::Function(Box::new(make_topexpr(tokenstream))),
     }
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,0 +1,58 @@
+use crate::lexer::{parse_input, TokenIter};
+// all of the possible Abstract Syntax Tree node expressions
+enum ExprAST<'a> {
+    Number(NumberExpr),
+    Variable(VariableExpr<'a>),
+    BinaryOp(&'a BinaryOpExpr<'a>),
+    CallOp(CallOpExpr<'a>),
+    FnType(FnTypeExpr<'a>),
+    Function(&'a FunctionExpr<'a>),
+}
+
+struct NumberExpr {
+    value: f64,
+}
+
+struct VariableExpr<'a> {
+    name: &'a str,
+}
+
+struct BinaryOpExpr<'a> {
+    op: char,
+    args: [ExprAST<'a>; 2],
+}
+
+struct CallOpExpr<'a> {
+    callee: &'a str,
+    args: Vec<ExprAST<'a>>,
+}
+
+struct FnTypeExpr<'a> {
+    name: &'a str,
+    args: Vec<&'a str>,
+}
+
+struct FunctionExpr<'a> {
+    ty: FnTypeExpr<'a>,
+    body: ExprAST<'a>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::iter::Peekable;
+
+    #[test]
+    fn test_binop() {
+        let input = "x + y";
+        let mut tok_iter = TokenIter::new(&input).peekable();
+
+        let lhs = ExprAST::Variable(VariableExpr { name: "x" });
+        let rhs = ExprAST::Variable(VariableExpr { name: "y" });
+
+        let result = BinaryOpExpr {
+            op: '+',
+            args: [lhs, rhs],
+        };
+    }
+}


### PR DESCRIPTION
Closes #4.

This PR implements a parser that builds an AST from an input string, which is intended to be read from a file. 

There are still rough edges that require cleaning up. In particular, the different `make_<ast_node>` functions do not all return in a uniform way, i.e. some return the `<ast_node_expr>` while others return the `ExprAST` enum.