### PR TITLE
Implement llvm ir codegen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,150 @@
 version = 3
 
 [[package]]
+name = "anyhow"
+version = "1.0.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
+
+[[package]]
+name = "cc"
+version = "1.0.90"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
+
+[[package]]
+name = "either"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
+
+[[package]]
+name = "inkwell"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b597a7b2cdf279aeef6d7149071e35e4bc87c2cf05a5b7f2d731300bffe587ea"
+dependencies = [
+ "either",
+ "inkwell_internals",
+ "libc",
+ "llvm-sys",
+ "once_cell",
+ "thiserror",
+]
+
+[[package]]
+name = "inkwell_internals"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fa4d8d74483041a882adaa9a29f633253a66dde85055f0495c121620ac484b2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "kaleidoscope"
 version = "0.1.0"
+dependencies = [
+ "inkwell",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "libc"
+version = "0.2.153"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+
+[[package]]
+name = "llvm-sys"
+version = "170.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed90f72df5504c0af2e3a08ee7762a4a3e42ec2605811fc19f64879de40c50a"
+dependencies = [
+ "anyhow",
+ "cc",
+ "lazy_static",
+ "libc",
+ "regex-lite",
+ "semver",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "regex-lite"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b661b2f27137bdbc16f00eda72866a92bb28af1753ffbd56744fb6e2e9cd8e"
+
+[[package]]
+name = "semver"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
+
+[[package]]
+name = "syn"
+version = "2.0.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7383cd0e49fff4b6b90ca5670bfd3e9d6a733b3f90c686605aa7eec8c4996032"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+inkwell = { version = "0.4.0", features = ["llvm17-0"] }

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -29,6 +29,13 @@ impl<'a> Compiler<'a> {
         match expr {
             ExprAST::Number(numexpr) => self.llvm_context.f64_type().const_float(numexpr.value),
             ExprAST::Variable(varexpr) => self.var_codegen(&varexpr).unwrap().clone(),
+            ExprAST::CallOp(callexpr) => self
+                .call_codegen(&callexpr)
+                .unwrap()
+                .try_as_basic_value()
+                .left()
+                .unwrap()
+                .into_float_value(),
             _ => panic!("Oh no!"),
         }
     }
@@ -182,7 +189,7 @@ mod tests {
 
     #[test]
     fn test_fngen() {
-        let input = "def foo(a) 2*a*a";
+        let input = "def foo(a) 2*a*a + foo(1)";
         let mut tokenstream = TokenIter::new(&input).peekable();
         tokenstream.next();
         let expr = make_function(&mut tokenstream);

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -1,14 +1,17 @@
 use std::collections::HashMap;
 
-use inkwell::builder::Builder;
+use inkwell::builder::{Builder, BuilderError};
 use inkwell::context::Context;
+use inkwell::module::Module;
 use inkwell::values::FloatValue;
 
-use crate::parser::{ExprAST, NumberExpr, VariableExpr};
+use crate::parser::{BinaryOpExpr, ExprAST, NumberExpr, VariableExpr};
 
 // not really the compiler but actually the current scope
 struct Compiler<'a> {
     llvm_context: &'a Context,
+    llvm_builder: Builder<'a>,
+    llvm_module: Module<'a>,
 
     // these are (function passed) variables,
     // which should be given some FloatValue already
@@ -16,13 +19,24 @@ struct Compiler<'a> {
 }
 
 impl<'a> Compiler<'a> {
-    fn float_codegen(self: &Self, numexpr: NumberExpr) -> FloatValue<'a> {
-        self.llvm_context.f64_type().const_float(numexpr.value)
+    fn float_codegen(self: &Self, expr: &ExprAST<'a>) -> FloatValue<'a> {
+        match expr {
+            ExprAST::Number(numexpr) => self.llvm_context.f64_type().const_float(numexpr.value),
+            _ => panic!("Oh no!"),
+        }
     }
 
     // gets the FloatValue stored in the hashmap of the compiler
     fn var_codegen(self: &Self, varexpr: VariableExpr) -> Option<&FloatValue<'a>> {
         self.variables.get(varexpr.name)
+    }
+
+    // this can only be called after a basic block has been added
+    // which is why a top level expression is an anonymous function
+    fn adder_codegen(self: &Self, binop: BinaryOpExpr<'a>) -> Result<FloatValue, BuilderError> {
+        let lhs = self.float_codegen(&binop.args[0]);
+        let rhs = self.float_codegen(&binop.args[1]);
+        self.llvm_builder.build_float_add(lhs, rhs, "addtmp")
     }
 }
 
@@ -30,29 +44,54 @@ impl<'a> Compiler<'a> {
 mod tests {
     use super::*;
     use crate::lexer::TokenIter;
-    use crate::parser::make_primitive;
+    use crate::parser::{make_expr, make_primitive};
 
     #[test]
     fn test_float_gen() {
         let input = "2.0";
         let mut tokenstream = TokenIter::new(&input).peekable();
-        let prim_2 = match make_primitive(tokenstream.next().as_ref()) {
-            Some(ExprAST::Number(tok)) => tok,
-            _ => panic!("Uh oh!"),
-        };
+        let prim_2 = make_primitive(tokenstream.next().as_ref()).unwrap();
 
         let llvm_context = Context::create();
         let compiler = Compiler {
             llvm_context: &llvm_context,
+            llvm_builder: llvm_context.create_builder(),
+            llvm_module: llvm_context.create_module("empty"),
             variables: HashMap::new(),
         };
 
         let result = llvm_context.f64_type().const_float(2.0);
 
-        let code = compiler.float_codegen(prim_2);
-
-        dbg!(code);
-        dbg!(result);
+        let code = compiler.float_codegen(&prim_2);
         assert_eq!(result, code);
+    }
+
+    #[test]
+    fn test_adder_gen() {
+        let input = "2.0 + 3.0";
+        let mut tokenstream = TokenIter::new(&input).peekable();
+        let binop = match make_expr(&mut tokenstream, 0) {
+            ExprAST::BinaryOp(binopexpr) => binopexpr,
+            _ => panic!("Oh no!"),
+        };
+
+        let llvm_context = Context::create();
+        let compiler = Compiler {
+            llvm_context: &llvm_context,
+            llvm_builder: llvm_context.create_builder(),
+            llvm_module: llvm_context.create_module("sum_test"),
+            variables: HashMap::new(),
+        };
+
+        // a workaround for top level expression an anonymous function
+        let anon_fn_type = llvm_context.f64_type().fn_type(&[], false);
+        let function = compiler
+            .llvm_module
+            .add_function("anon_sum", anon_fn_type, None);
+        let basic_block = compiler.llvm_context.append_basic_block(function, "entry");
+        compiler.llvm_builder.position_at_end(basic_block);
+
+        let code = compiler.adder_codegen(*binop).unwrap();
+        println!("{code}");
     }
 }

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -1,0 +1,58 @@
+use std::collections::HashMap;
+
+use inkwell::builder::Builder;
+use inkwell::context::Context;
+use inkwell::values::FloatValue;
+
+use crate::parser::{ExprAST, NumberExpr, VariableExpr};
+
+// not really the compiler but actually the current scope
+struct Compiler<'a> {
+    llvm_context: &'a Context,
+
+    // these are (function passed) variables,
+    // which should be given some FloatValue already
+    variables: HashMap<&'a str, FloatValue<'a>>,
+}
+
+impl<'a> Compiler<'a> {
+    fn float_codegen(self: &Self, numexpr: NumberExpr) -> FloatValue<'a> {
+        self.llvm_context.f64_type().const_float(numexpr.value)
+    }
+
+    // gets the FloatValue stored in the hashmap of the compiler
+    fn var_codegen(self: &Self, varexpr: VariableExpr) -> Option<&FloatValue<'a>> {
+        self.variables.get(varexpr.name)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lexer::TokenIter;
+    use crate::parser::make_primitive;
+
+    #[test]
+    fn test_float_gen() {
+        let input = "2.0";
+        let mut tokenstream = TokenIter::new(&input).peekable();
+        let prim_2 = match make_primitive(tokenstream.next().as_ref()) {
+            Some(ExprAST::Number(tok)) => tok,
+            _ => panic!("Uh oh!"),
+        };
+
+        let llvm_context = Context::create();
+        let compiler = Compiler {
+            llvm_context: &llvm_context,
+            variables: HashMap::new(),
+        };
+
+        let result = llvm_context.f64_type().const_float(2.0);
+
+        let code = compiler.float_codegen(prim_2);
+
+        dbg!(code);
+        dbg!(result);
+        assert_eq!(result, code);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,3 @@
+pub mod codegen;
 pub mod lexer;
 pub mod parser;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -22,9 +22,9 @@ pub struct VariableExpr<'a> {
 }
 
 #[derive(Debug, PartialEq)]
-struct BinaryOpExpr<'a> {
-    op: char,
-    args: [ExprAST<'a>; 2],
+pub struct BinaryOpExpr<'a> {
+    pub op: char,
+    pub args: [ExprAST<'a>; 2],
 }
 
 #[derive(Debug, PartialEq)]
@@ -75,7 +75,7 @@ fn get_opcode<'a>(token: Option<&Token<'a>>) -> (char, i32) {
 // the prec is the precendence binding value of the operation
 // this currently only makes an expression with all rhs expanded
 // a parser needs to construct the total AST
-fn make_expr<'a>(tokenstream: &mut Peekable<TokenIter<'a>>, prec: i32) -> ExprAST<'a> {
+pub fn make_expr<'a>(tokenstream: &mut Peekable<TokenIter<'a>>, prec: i32) -> ExprAST<'a> {
     let mut lhs = make_primitive(tokenstream.next().as_ref());
 
     loop {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2,7 +2,7 @@ use crate::lexer::{parse_input, Token, TokenIter};
 use std::iter::Peekable;
 // all of the possible Abstract Syntax Tree node expressions
 #[derive(Debug, PartialEq)]
-enum ExprAST<'a> {
+pub enum ExprAST<'a> {
     Number(NumberExpr),
     Variable(VariableExpr<'a>),
     BinaryOp(Box<BinaryOpExpr<'a>>),
@@ -12,13 +12,13 @@ enum ExprAST<'a> {
 }
 
 #[derive(Debug, PartialEq)]
-struct NumberExpr {
-    value: f64,
+pub struct NumberExpr {
+    pub value: f64,
 }
 
 #[derive(Debug, PartialEq)]
-struct VariableExpr<'a> {
-    name: &'a str,
+pub struct VariableExpr<'a> {
+    pub name: &'a str,
 }
 
 #[derive(Debug, PartialEq)]
@@ -46,7 +46,7 @@ struct FunctionExpr<'a> {
 }
 
 // A primitive AST node is without any sub-nodes
-fn make_primitive<'a>(token: Option<&Token<'a>>) -> Option<ExprAST<'a>> {
+pub fn make_primitive<'a>(token: Option<&Token<'a>>) -> Option<ExprAST<'a>> {
     match token {
         Some(Token::Identifier(str)) => Some(ExprAST::Variable(VariableExpr { name: str })),
         Some(Token::Number(value)) => Some(ExprAST::Number(NumberExpr {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -28,21 +28,21 @@ pub struct BinaryOpExpr<'a> {
 }
 
 #[derive(Debug, PartialEq)]
-struct CallOpExpr<'a> {
-    callee: &'a str,
-    args: Vec<ExprAST<'a>>,
+pub struct CallOpExpr<'a> {
+    pub callee: &'a str,
+    pub args: Vec<ExprAST<'a>>,
 }
 
 #[derive(Debug, PartialEq)]
-struct FnTypeExpr<'a> {
-    name: &'a str,
-    args: Vec<VariableExpr<'a>>,
+pub struct FnTypeExpr<'a> {
+    pub name: &'a str,
+    pub args: Vec<VariableExpr<'a>>,
 }
 
 #[derive(Debug, PartialEq)]
-struct FunctionExpr<'a> {
-    ty: FnTypeExpr<'a>,
-    body: ExprAST<'a>,
+pub struct FunctionExpr<'a> {
+    pub ty: FnTypeExpr<'a>,
+    pub body: ExprAST<'a>,
 }
 
 // A primitive AST node is without any sub-nodes
@@ -92,7 +92,10 @@ pub fn make_expr<'a>(tokenstream: &mut Peekable<TokenIter<'a>>, prec: i32) -> Ex
             args: [lhs.unwrap(), rhs],
         })));
     }
-    lhs.unwrap()
+    match lhs {
+        Some(lhs) => lhs,
+        None => panic!("What is going on?!"),
+    }
 }
 
 fn make_signature<'a>(tokenstream: &mut Peekable<TokenIter<'a>>) -> FnTypeExpr<'a> {
@@ -124,14 +127,14 @@ fn make_signature<'a>(tokenstream: &mut Peekable<TokenIter<'a>>) -> FnTypeExpr<'
     }
 }
 
-fn make_function<'a>(tokenstream: &mut Peekable<TokenIter<'a>>) -> FunctionExpr<'a> {
+pub fn make_function<'a>(tokenstream: &mut Peekable<TokenIter<'a>>) -> FunctionExpr<'a> {
     let ty = make_signature(tokenstream);
     let body = make_expr(tokenstream, 0);
     FunctionExpr { ty, body }
 }
 
 // parsers a top level expression into an anonymous function
-fn make_topexpr<'a>(tokenstream: &mut Peekable<TokenIter<'a>>) -> FunctionExpr<'a> {
+pub fn make_topexpr<'a>(tokenstream: &mut Peekable<TokenIter<'a>>) -> FunctionExpr<'a> {
     let topty = FnTypeExpr {
         name: "",
         args: Vec::new(),
@@ -140,7 +143,7 @@ fn make_topexpr<'a>(tokenstream: &mut Peekable<TokenIter<'a>>) -> FunctionExpr<'
     FunctionExpr { ty: topty, body }
 }
 
-fn make_ast<'a>(tokenstream: &mut Peekable<TokenIter<'a>>) -> ExprAST<'a> {
+pub fn make_ast<'a>(tokenstream: &mut Peekable<TokenIter<'a>>) -> ExprAST<'a> {
     match tokenstream.peek() {
         Some(Token::Def) => {
             tokenstream.next();
@@ -211,7 +214,7 @@ mod tests {
 
     #[test]
     fn test_fndef() {
-        let input = "def multiply(x,y) x*y";
+        let input = "def multiply(x, y) x*y";
         let mut tokenstream = TokenIter::new(&input).peekable();
 
         let var_x = VariableExpr { name: "x" };


### PR DESCRIPTION
Closes #6.

Currently, the IR generation does not work for function calls because these are not parsed! As part of the changes, the AST for a function call needs to be added.